### PR TITLE
misc fixes to `gold_nmdc.json`

### DIFF
--- a/sample_annotator/clients/nmdc/gold_client_wrapper.py
+++ b/sample_annotator/clients/nmdc/gold_client_wrapper.py
@@ -5,7 +5,6 @@ import pkgutil
 import logging
 
 from typing import Dict, List, Union
-from attr import has
 
 import jsonschema
 import pandas as pd
@@ -298,7 +297,7 @@ class GoldNMDC(GoldClient):
                         type="nmdc:OmicsProcessing",
                         has_input="gold:" + project["biosampleGoldId"],
                         has_output=has_output,
-                        part_of="gold:" + self.study_id,
+                        part_of=self.study_id,
                         
                         # omics processing date fields
                         add_date=XSDDateTime(project["addDate"]),

--- a/sample_annotator/clients/nmdc/gold_client_wrapper.py
+++ b/sample_annotator/clients/nmdc/gold_client_wrapper.py
@@ -87,7 +87,7 @@ class GoldNMDC(GoldClient):
 
         with open(read_qc_path) as f:
             read_qc_array = json.load(f)
-        
+
         read_qc_list = []
 
         for item in read_qc_array:
@@ -132,15 +132,11 @@ class GoldNMDC(GoldClient):
         biosamples = [
             samp for samp in biosamples if samp["biosampleGoldId"] in soil_biosamples
         ]
-        
+
         study_data = self.fetch_study(id=self.study_id)
 
         pi_dict = next(
-            (
-                contact
-                for contact in study_data["contacts"]
-                if "PI" in contact["roles"]
-            )
+            (contact for contact in study_data["contacts"] if "PI" in contact["roles"])
         )
 
         self.nmdc_db.study_set.append(
@@ -152,7 +148,7 @@ class GoldNMDC(GoldClient):
                 principal_investigator=nmdc.PersonValue(
                     has_raw_value=pi_dict["name"],
                     name=pi_dict["name"],
-                    email=pi_dict["email"]
+                    email=pi_dict["email"],
                 ),
                 type="nmdc:Study",
             )
@@ -194,7 +190,7 @@ class GoldNMDC(GoldClient):
                             has_numeric_value=biosample["depthInMeters"],
                             has_unit="meter",
                         ),
-
+                        
                         # TODO: this is temporary non MIxS that can
                         # hopefully be eliminated sooner rather than later
                         depth2=nmdc.QuantityValue(
@@ -241,18 +237,18 @@ class GoldNMDC(GoldClient):
                         
                         # environment metadata fields
                         env_broad_scale=nmdc.ControlledTermValue(
-                            term=nmdc.OntologyClass(
-                                biosample["envoBroadScale"]["id"].replace("_", ":")
+                            has_raw_value=biosample["envoBroadScale"]["id"].replace(
+                                "_", ":"
                             )
                         ),
                         env_local_scale=nmdc.ControlledTermValue(
-                            term=nmdc.OntologyClass(
-                                biosample["envoLocalScale"]["id"].replace("_", ":")
+                            has_raw_value=biosample["envoLocalScale"]["id"].replace(
+                                "_", ":"
                             )
                         ),
                         env_medium=nmdc.ControlledTermValue(
-                            term=nmdc.OntologyClass(
-                                biosample["envoMedium"]["id"].replace("_", ":")
+                            has_raw_value=biosample["envoMedium"]["id"].replace(
+                                "_", ":"
                             )
                         ),
                     )
@@ -282,6 +278,7 @@ class GoldNMDC(GoldClient):
                 )
 
                 project_has_output_dict = self.project_has_output_dict()
+                
                 # create value for has_output attribute
                 if project["projectGoldId"] in self.project_has_output_dict():
                     has_output = project_has_output_dict[project["projectGoldId"]]

--- a/tests/output/gold_nmdc.json
+++ b/tests/output/gold_nmdc.json
@@ -8,19 +8,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -58,19 +52,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -108,19 +96,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000119"
-                }
+                "has_raw_value": "ENVO:00000119"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -158,19 +140,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -208,19 +184,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -258,19 +228,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -308,19 +272,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000161"
-                }
+                "has_raw_value": "ENVO:00000161"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -358,19 +316,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -408,19 +360,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -458,19 +404,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -508,19 +448,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -558,19 +492,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -608,19 +536,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -658,19 +580,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -708,19 +624,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -758,19 +668,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000183"
-                }
+                "has_raw_value": "ENVO:01000183"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000170"
-                }
+                "has_raw_value": "ENVO:00000170"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005800"
-                }
+                "has_raw_value": "ENVO:00005800"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -808,19 +712,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -858,19 +756,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -908,19 +800,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -958,19 +844,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1008,19 +888,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1058,19 +932,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1108,19 +976,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1158,19 +1020,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1208,19 +1064,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000892"
-                }
+                "has_raw_value": "ENVO:01000892"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1258,19 +1108,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000892"
-                }
+                "has_raw_value": "ENVO:01000892"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1308,19 +1152,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1358,19 +1196,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1408,19 +1240,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000161"
-                }
+                "has_raw_value": "ENVO:00000161"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1458,19 +1284,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000161"
-                }
+                "has_raw_value": "ENVO:00000161"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1508,19 +1328,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1558,19 +1372,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1608,19 +1416,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1658,19 +1460,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1708,19 +1504,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1758,19 +1548,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000119"
-                }
+                "has_raw_value": "ENVO:00000119"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1808,19 +1592,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1858,19 +1636,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1908,19 +1680,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -1958,19 +1724,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2008,19 +1768,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2058,19 +1812,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2108,19 +1856,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2158,19 +1900,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2208,19 +1944,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2258,19 +1988,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2308,19 +2032,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2358,19 +2076,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000247"
-                }
+                "has_raw_value": "ENVO:01000247"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2408,19 +2120,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:00000873"
-                }
+                "has_raw_value": "ENVO:00000873"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000687"
-                }
+                "has_raw_value": "ENVO:01000687"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00002007"
-                }
+                "has_raw_value": "ENVO:00002007"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2461,19 +2167,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2511,19 +2211,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000119"
-                }
+                "has_raw_value": "ENVO:00000119"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2561,19 +2255,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000221"
-                }
+                "has_raw_value": "ENVO:01000221"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000221"
-                }
+                "has_raw_value": "ENVO:01000221"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2611,19 +2299,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000094"
-                }
+                "has_raw_value": "ENVO:00000094"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:01001841"
-                }
+                "has_raw_value": "ENVO:01001841"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2661,19 +2343,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2711,19 +2387,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2761,19 +2431,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2811,19 +2475,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2861,19 +2519,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2911,19 +2563,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -2961,19 +2607,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3011,19 +2651,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000094"
-                }
+                "has_raw_value": "ENVO:00000094"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:01001841"
-                }
+                "has_raw_value": "ENVO:01001841"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3061,19 +2695,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3111,19 +2739,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3161,19 +2783,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000249"
-                }
+                "has_raw_value": "ENVO:01000249"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000120"
-                }
+                "has_raw_value": "ENVO:00000120"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3211,19 +2827,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000183"
-                }
+                "has_raw_value": "ENVO:01000183"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000548"
-                }
+                "has_raw_value": "ENVO:00000548"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:01000018"
-                }
+                "has_raw_value": "ENVO:01000018"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3261,19 +2871,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3311,19 +2915,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3361,19 +2959,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000211"
-                }
+                "has_raw_value": "ENVO:01000211"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3411,19 +3003,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000215"
-                }
+                "has_raw_value": "ENVO:01000215"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000215"
-                }
+                "has_raw_value": "ENVO:01000215"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3461,19 +3047,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000221"
-                }
+                "has_raw_value": "ENVO:01000221"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000221"
-                }
+                "has_raw_value": "ENVO:01000221"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3511,19 +3091,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000892"
-                }
+                "has_raw_value": "ENVO:01000892"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3561,19 +3135,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:00000873"
-                }
+                "has_raw_value": "ENVO:00000873"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000687"
-                }
+                "has_raw_value": "ENVO:01000687"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00002007"
-                }
+                "has_raw_value": "ENVO:00002007"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3614,19 +3182,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000245"
-                }
+                "has_raw_value": "ENVO:01000245"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000119"
-                }
+                "has_raw_value": "ENVO:00000119"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:02000059"
-                }
+                "has_raw_value": "ENVO:02000059"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3664,19 +3226,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3714,19 +3270,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000179"
-                }
+                "has_raw_value": "ENVO:01000179"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000185"
-                }
+                "has_raw_value": "ENVO:01000185"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005741"
-                }
+                "has_raw_value": "ENVO:00005741"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3764,19 +3314,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3814,19 +3358,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000250"
-                }
+                "has_raw_value": "ENVO:01000250"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:01000355"
-                }
+                "has_raw_value": "ENVO:01000355"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00005774"
-                }
+                "has_raw_value": "ENVO:00005774"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3864,19 +3402,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000094"
-                }
+                "has_raw_value": "ENVO:00000094"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:01001841"
-                }
+                "has_raw_value": "ENVO:01001841"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3914,19 +3446,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000174"
-                }
+                "has_raw_value": "ENVO:01000174"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00000094"
-                }
+                "has_raw_value": "ENVO:00000094"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:01001841"
-                }
+                "has_raw_value": "ENVO:01001841"
             },
             "type": "nmdc:Biosample",
             "depth": {
@@ -3964,19 +3490,13 @@
                 "gold:Gs0154244"
             ],
             "env_broad_scale": {
-                "term": {
-                    "id": "ENVO:01000219"
-                }
+                "has_raw_value": "ENVO:01000219"
             },
             "env_local_scale": {
-                "term": {
-                    "id": "ENVO:00002204"
-                }
+                "has_raw_value": "ENVO:00002204"
             },
             "env_medium": {
-                "term": {
-                    "id": "ENVO:00001998"
-                }
+                "has_raw_value": "ENVO:00001998"
             },
             "type": "nmdc:Biosample",
             "depth": {

--- a/tests/output/gold_nmdc.json
+++ b/tests/output/gold_nmdc.json
@@ -4041,7 +4041,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4072,7 +4072,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4103,7 +4103,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4134,7 +4134,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4166,7 +4166,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4195,7 +4195,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4226,7 +4226,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4255,7 +4255,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4286,7 +4286,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4315,7 +4315,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4345,7 +4345,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4374,7 +4374,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4406,7 +4406,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4436,7 +4436,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4467,7 +4467,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4497,7 +4497,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4527,7 +4527,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4556,7 +4556,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4585,7 +4585,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4615,7 +4615,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4645,7 +4645,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4675,7 +4675,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4707,7 +4707,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4737,7 +4737,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4769,7 +4769,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4800,7 +4800,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4830,7 +4830,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4861,7 +4861,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4890,7 +4890,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4921,7 +4921,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4951,7 +4951,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -4980,7 +4980,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5010,7 +5010,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5040,7 +5040,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5069,7 +5069,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5100,7 +5100,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5131,7 +5131,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5161,7 +5161,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5190,7 +5190,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5221,7 +5221,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5252,7 +5252,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5282,7 +5282,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5313,7 +5313,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5344,7 +5344,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5375,7 +5375,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5406,7 +5406,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5437,7 +5437,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5469,7 +5469,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5501,7 +5501,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5530,7 +5530,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5562,7 +5562,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5592,7 +5592,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5621,7 +5621,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5652,7 +5652,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5682,7 +5682,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5713,7 +5713,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5743,7 +5743,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5775,7 +5775,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5806,7 +5806,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5838,7 +5838,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5869,7 +5869,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5901,7 +5901,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5931,7 +5931,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5963,7 +5963,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -5994,7 +5994,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6024,7 +6024,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6053,7 +6053,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6083,7 +6083,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6112,7 +6112,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6144,7 +6144,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6174,7 +6174,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6204,7 +6204,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6233,7 +6233,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6263,7 +6263,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6293,7 +6293,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6323,7 +6323,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6353,7 +6353,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6384,7 +6384,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6414,7 +6414,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",
@@ -6444,7 +6444,7 @@
                 "has_raw_value": "Metagenome"
             },
             "part_of": [
-                "gold:gold:Gs0154244"
+                "gold:Gs0154244"
             ],
             "principal_investigator": {
                 "has_raw_value": "Janet Jansson",


### PR DESCRIPTION
* remove double `gold:` prefix on `part_of` attribute
* revert EnvO term structure to using traditional `has_raw_value` format