### PR TITLE
add gold client methods that use GOLD project and analysis ids

### DIFF
--- a/sample_annotator/clients/gold_client.py
+++ b/sample_annotator/clients/gold_client.py
@@ -251,6 +251,28 @@ class GoldClient:
                     ids.append(line.strip())
         return self.fetch_studies(ids, **kwargs)
 
+    def fetch_biosamples_by_project(self, id: str) -> List[SampleDict]:
+        """Fetch the biosample from which the sequencing project
+        was generated.
+
+        :param id: GOLD project id. Ex.: Gp0503330
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("biosamples", {"projectGoldId": id})
+        return results
+
+    def fetch_study_by_project(self, id: str) -> List[SampleDict]:
+        """Fetch the study for which the sequencing project
+        was performed.
+
+        :param id: GOLD project id. Ex.: Gp0503330
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("studies", {"projectGoldId": id})
+        return results
+        
 
 @click.group()
 @click.option("-v", "--verbose", count=True)

--- a/sample_annotator/clients/gold_client.py
+++ b/sample_annotator/clients/gold_client.py
@@ -251,7 +251,7 @@ class GoldClient:
                     ids.append(line.strip())
         return self.fetch_studies(ids, **kwargs)
 
-    def fetch_biosamples_by_project(self, id: str) -> List[SampleDict]:
+    def fetch_biosample_by_project(self, id: str) -> List[SampleDict]:
         """Fetch the biosample from which the sequencing project
         was generated.
 
@@ -260,7 +260,9 @@ class GoldClient:
         """
         id = self._normalize_id(id)
         results = self._call("biosamples", {"projectGoldId": id})
-        return results
+        
+        biosample_id = results[0]["biosampleGoldId"]
+        return biosample_id
 
     def fetch_study_by_project(self, id: str) -> List[SampleDict]:
         """Fetch the study for which the sequencing project
@@ -271,7 +273,9 @@ class GoldClient:
         """
         id = self._normalize_id(id)
         results = self._call("studies", {"projectGoldId": id})
-        return results
+
+        study_id = results[0]["studyGoldId"]
+        return study_id
 
     def fetch_study_by_analysis_id(self, id: str) -> List[SampleDict]:
         """Fetch the study id for which the informatics processing 
@@ -280,8 +284,10 @@ class GoldClient:
         :return: List of SampleDict objects
         """
         id = self._normalize_id(id)
-        results = self._call("studies", {"analysisGoldId": id})
-        return results
+        results = self._call("studies", {"apGoldId": id})
+
+        study_id = results[0]["studyGoldId"]
+        return study_id
 
     def fetch_biosample_by_analysis_id(self, id: str) -> List[SampleDict]:
         """Fetch the biosample id for which the informatics processing 
@@ -290,8 +296,10 @@ class GoldClient:
         :return: List of SampleDict objects
         """
         id = self._normalize_id(id)
-        results = self._call("biosamples", {"analysisGoldId": id})
-        return results
+        results = self._call("biosamples", {"apGoldId": id})
+
+        biosample_id = results[0]["biosampleGoldId"]
+        return biosample_id
 
     def fetch_project_by_analysis_id(self, id: str) -> List[SampleDict]:
         """Fetch the project id for which the informatics processing 
@@ -300,8 +308,10 @@ class GoldClient:
         :return: List of SampleDict objects
         """
         id = self._normalize_id(id)
-        results = self._call("projects", {"analysisGoldId": id})
-        return results
+        results = self._call("projects", {"apGoldId": id})
+
+        project_id = results[0]["projectGoldId"]
+        return project_id
         
 
 @click.group()

--- a/sample_annotator/clients/gold_client.py
+++ b/sample_annotator/clients/gold_client.py
@@ -272,6 +272,36 @@ class GoldClient:
         id = self._normalize_id(id)
         results = self._call("studies", {"projectGoldId": id})
         return results
+
+    def fetch_study_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the study id for which the informatics processing 
+        of a sequencing project was performed.
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("studies", {"analysisGoldId": id})
+        return results
+
+    def fetch_biosample_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the biosample id for which the informatics processing 
+        of a sequencing project was performed.
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("biosamples", {"analysisGoldId": id})
+        return results
+
+    def fetch_project_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the project id for which the informatics processing 
+        of a sequencing project was performed.
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("projects", {"analysisGoldId": id})
+        return results
         
 
 @click.group()

--- a/tests/test_gold.py
+++ b/tests/test_gold.py
@@ -21,6 +21,7 @@ TEST_BIOSAMPLE_IDS = ['Gb0255525', 'Gb0255899', 'Gb0255966',  ## in Gs0144570
                       'Gb0011929',
                       'Gb0051032'  ## sample with no study
                       ]
+TEST_PROJECT_ID = 'Gp0503317'
 
 #logging.basicConfig(level=logging.DEBUG)
 
@@ -88,3 +89,25 @@ class TestGoldClient(unittest.TestCase):
         else:
             print(f'Skipping sample tests')
             print(f'To enable these, add your apikey to {KEYPATH}')
+
+    def test_fetches_by_project(self):
+        """Tests for all methods in the library that seek to fetch 
+        biosample and study information from gold database based on 
+        supplied project ids.
+        """
+        gc = GoldClient()
+        gc.clear_cache()
+
+        if os.path.exists(KEYPATH):
+            gc.load_key(KEYPATH)
+
+            expected_biosample_id = 'Gb0258249'
+            actual_biosample_id = gc.fetch_biosample_by_project(TEST_PROJECT_ID)
+
+            self.assertEqual(expected_biosample_id, actual_biosample_id)
+
+            expected_study_id = 'Gs0149396'
+            actual_study_id = gc.fetch_study_by_project(TEST_PROJECT_ID)
+
+            self.assertEqual(expected_study_id, actual_study_id)
+            

--- a/tests/test_gold.py
+++ b/tests/test_gold.py
@@ -22,6 +22,7 @@ TEST_BIOSAMPLE_IDS = ['Gb0255525', 'Gb0255899', 'Gb0255966',  ## in Gs0144570
                       'Gb0051032'  ## sample with no study
                       ]
 TEST_PROJECT_ID = 'Gp0503317'
+TEST_ANALYSIS_ID = 'Ga0451502'
 
 #logging.basicConfig(level=logging.DEBUG)
 
@@ -110,4 +111,30 @@ class TestGoldClient(unittest.TestCase):
             actual_study_id = gc.fetch_study_by_project(TEST_PROJECT_ID)
 
             self.assertEqual(expected_study_id, actual_study_id)
+            
+    def test_fetches_by_analysis(self):
+        """Tests for all methods in the library that seek to fetch 
+        biosample, study and project information from gold database based 
+        on supplied project analysis ids.
+        """
+        gc = GoldClient()
+        gc.clear_cache()
+
+        if os.path.exists(KEYPATH):
+            gc.load_key(KEYPATH)
+
+            expected_biosample_id = 'Gb0258249'
+            actual_biosample_id = gc.fetch_biosample_by_analysis_id(TEST_ANALYSIS_ID)
+
+            self.assertEqual(expected_biosample_id, actual_biosample_id)
+
+            expected_study_id = 'Gs0149396'
+            actual_study_id = gc.fetch_study_by_analysis_id(TEST_ANALYSIS_ID)
+
+            self.assertEqual(expected_study_id, actual_study_id)
+
+            expected_project_id = TEST_PROJECT_ID
+            actual_project_id = gc.fetch_project_by_analysis_id(TEST_ANALYSIS_ID)
+
+            self.assertEqual(expected_project_id, actual_project_id)
             


### PR DESCRIPTION
This PR seeks to add two methods to the GOLD client library that fetches biosamples and study by project id.

This is a direct necessity for the GROW dataset, since we have only Gp and Ga ids to work with. Perhaps it would be a good idea to add `get_project_by_analysis_id()`, `get_biosample_by_analysis_id()` and `get_study_by_analysis_id()` in the future too.