### PR TITLE
add methods to filter by analysis ids

### DIFF
--- a/sample_annotator/clients/gold_client.py
+++ b/sample_annotator/clients/gold_client.py
@@ -272,7 +272,39 @@ class GoldClient:
         id = self._normalize_id(id)
         results = self._call("studies", {"projectGoldId": id})
         return results
-        
+
+    def fetch_study_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the study id for which the informatics processing 
+        of a sequencing project was performed.
+
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("studies", {"analysisGoldId": id})
+        return results
+
+    def fetch_biosample_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the biosample id for which the informatics processing 
+        of a sequencing project was performed.
+
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("biosamples", {"analysisGoldId": id})
+        return results
+
+    def fetch_project_by_analysis_id(self, id: str) -> List[SampleDict]:
+        """Fetch the project id for which the informatics processing 
+        of a sequencing project was performed.
+
+        :param id: GOLD Analysis id. Ex.: Ga0466468
+        :return: List of SampleDict objects
+        """
+        id = self._normalize_id(id)
+        results = self._call("projects", {"analysisGoldId": id})
+        return results
 
 @click.group()
 @click.option("-v", "--verbose", count=True)


### PR DESCRIPTION
This is a follow up to PR #102, which seeks to add methods to the GOLD client library that fetches study, biosample and project id information based on analysis id.

There is no immediate reason for adding these methods, but much in the same way like the project id based filtering methods have utility, the analysis id based filtering methods will have utility too.